### PR TITLE
Fix for modern kakoune

### DIFF
--- a/digraphs.kak
+++ b/digraphs.kak
@@ -110,17 +110,17 @@ digraphs-search-symbol %{
             # Display first result before building menu. Awk fields: $1 = hex
             # value, $2 = symbol, $3 = description, $4 = digraph.
             printf %s\\n "$results" | head -n 1 | awk '
-                BEGIN { FS = "\t" } { printf "echo -- %%{U+%s %s}\n", $1, $4 }
+                BEGIN { FS = "\t" } { printf "echo %%{U+%s %s}\n", $1, $4 }
             '
             printf %s\\n "$results" | awk '
                 BEGIN {
                     FS = "\t"
-                    printf "menu -select-cmds -- "
+                    printf "menu -select-cmds "
                 }
                 {
                     printf "%%{%s %s} ", $2, $3
                     printf "%%{digraphs-accept-symbol %%{%s}} ", $2
-                    printf "%%{echo -- %%{U+%s %s}} ", $1, $4
+                    printf "%%{echo %%{U+%s %s}} ", $1, $4
                 }
             '
         }


### PR DESCRIPTION
`--` flags aren't documented and seems at some point `:menu` stopped working because of that. None of the arguments start with `-`, so it should be fine